### PR TITLE
Fix RadMech desync issues

### DIFF
--- a/source/Plugin.cs
+++ b/source/Plugin.cs
@@ -692,6 +692,30 @@ namespace LethalFixes
             }
         }
 
+        // [Client] Fix RadMech teleporting to flight destinations on client for every flight after the first
+        // [Client] Fix RadMech desyncing on clients (invisible robot bug)
+        private static FieldInfo finishingFlight = AccessTools.Field(typeof(RadMechAI), "finishingFlight");
+        private static FieldInfo inFlyingMode = AccessTools.Field(typeof(RadMechAI), "inFlyingMode");
+        [HarmonyPatch(typeof(RadMechAI), "Update")]
+        [HarmonyPrefix]
+        public static void RadMech_SetFinishingFlight(RadMechAI __instance)
+        {
+            if (__instance.currentBehaviourStateIndex != 2) //if we're not in the flying state
+            {
+                finishingFlight.SetValue(__instance, false); //set finishingFlight back to false to fix teleporting on the next flight
+
+                if ((bool)inFlyingMode.GetValue(__instance)) //isFlying is true but we're not in the flying state, desync bug happened
+                {
+                    inFlyingMode.SetValue(__instance, false);
+                    __instance.inSpecialAnimation = false;
+                    Debug.Log("Fixed invisible robot bug occurrence!");
+                }
+            }
+
+
+
+        }
+
         // [Host] Fixed enemies being able to be assigned to vents that were already occupied during the same hour
         [HarmonyPatch(typeof(RoundManager), "AssignRandomEnemyToVent")]
         [HarmonyPrefix]


### PR DESCRIPTION
This patch fixes two major issues with RadMechs for clients.

- After the first flight, clients would not set `RadMechAI.finishingFlight` back to false in `RadMechAI.Update`. This has the effect of robots teleporting to their destination upon takeoff immediately for clients, and landing long before they do for the host, standing idle until the host catches up.
- If the RadMech lands hostside before it does clientside for any reason, the host would switch the `EnemyAI.currentBehaviourState` to 0 before the clientside mech lands. This has the result of the client not updating several variables associated with landing which are normally set in `RadMechAI.Update`, most importantly not setting `EnemyAI.inSpecialAnimation` back to false. This prevents the clientside RadMech from updating it's position with the server position. This causes the 'invisible robot' bug.