### PR TITLE
Fix nutcracker aim-walk on clients

### DIFF
--- a/source/Plugin.cs
+++ b/source/Plugin.cs
@@ -711,9 +711,23 @@ namespace LethalFixes
                     Debug.Log("Fixed invisible robot bug occurrence!");
                 }
             }
+        }
 
+        // [Client] Fix Nutcracker not moving while aiming
+        [HarmonyPatch(typeof(NutcrackerEnemyAI), "AimGunClientRpc")]
+        [HarmonyPostfix]
+        static void Nutcracker_FixClientMovement(NutcrackerEnemyAI __instance)
+        {
+            __instance.transform.position = __instance.serverPosition;
+            __instance.inSpecialAnimation = false; //this bool disables the nutcracker position sync when true, stopping clients from seeing the aim-walk
+        }
 
-
+        [HarmonyPatch(typeof(NutcrackerEnemyAI), "Start")]
+        [HarmonyPostfix]
+        public static void Nutcracker_Start(NutcrackerEnemyAI __instance)
+        {
+            // Improve sync accuracy of nutcrackers hostside, will make their aim-walk less jerky in conjunction with the above fix
+            __instance.updatePositionThreshold = 0.5f;
         }
 
         // [Host] Fixed enemies being able to be assigned to vents that were already occupied during the same hour


### PR DESCRIPTION
Due to the setting of `EnemyAI.inSpecialAnimation` to true in `NutcrackerEnemyAI.AimGun`, clients would not sync the hosts movement throughout the nutcrackers aim, and thus would not see the aim-walk. Patched by setting it back to false.

Additionally, a second patch to improve the sync accuracy of the nutcracker host-side by halving the `EnemyAI.updatePositionThreshold` to 0.5 improves the smoothness of the aim-walk for clients, as the slow movement would result in a slightly inconsistent speed due to the somewhat large position threshold to sync.