### PR TITLE
Fix stormy weather targeted lightning breaking after the first time

### DIFF
--- a/source/Plugin.cs
+++ b/source/Plugin.cs
@@ -150,6 +150,14 @@ namespace LethalFixes
             }
         }
 
+        // [Host] Fixed stormy weather typically only working once each session
+        [HarmonyPatch(typeof(StormyWeather), "OnDisable")]
+        [HarmonyPostfix]
+        public static void Fix_StormyNullRef(ref StormyWeather __instance)
+        {
+            ((List<GrabbableObject>)metalObjects.GetValue(__instance)).Clear();
+        }
+
         // [Host] Fixed flooded weather only working for the first day of each session
         private static FieldInfo nextTimeSync = AccessTools.Field(typeof(TimeOfDay), "nextTimeSync");
         [HarmonyPatch(typeof(StartOfRound), "ResetStats")]


### PR DESCRIPTION
The `StormyWeather.metalObjects` list does not reset between days, resulting in any conductive items left behind on stormy moons leaving null references in this list when destroyed. Since any items on future stormy days are added after old ones, these nulls would cause `StormyWeather.Update` to throw a NullReferenceException before any new items can be checked, essentially breaking targeted lightning for the rest of the session.

Fixed by clearing the metalObjects list in `StormyWeather.OnDisable`. Only the host needs this patch.